### PR TITLE
Remove hydration in favor of explicit dependencies

### DIFF
--- a/lib/routr-plugin.js
+++ b/lib/routr-plugin.js
@@ -38,24 +38,6 @@ module.exports = function routrPlugin(options) {
             };
         },
         /**
-         * Called to dehydrate plugin options
-         * @method dehydrate
-         * @returns {Object}
-         */
-        dehydrate: function dehydrate() {
-            return {
-                routes: routes
-            };
-        },
-        /**
-         * Called to rehydrate plugin options
-         * @method rehydrate
-         * @returns {Object}
-         */
-        rehydrate: function rehydrate(state) {
-            routes = state.routes;
-        },
-        /**
          * @method getRoutes
          * @returns {Object}
          */

--- a/tests/unit/lib/routr-plugin.js
+++ b/tests/unit/lib/routr-plugin.js
@@ -70,41 +70,4 @@ describe('fetchrPlugin', function () {
         });
     });
 
-    describe('dehydrate', function () {
-        it('should dehydrate its state correctly', function () {
-            expect(pluginInstance.dehydrate()).to.deep.equal({
-                routes: routes
-            });
-        });
-    });
-
-    describe('rehydrate', function () {
-        var newRoutes = {
-            foo: {
-                path: '/bar',
-                method: 'get'
-            }
-        };
-        it('should rehydrate the state correctly', function () {
-            pluginInstance.rehydrate({
-                routes: newRoutes
-            });
-            expect(pluginInstance.dehydrate()).to.deep.equal({
-                routes: newRoutes
-            });
-        });
-        it('should use rehydrated routes', function () {
-            var a = new FluxibleApp();
-            var p = routrPlugin();
-            p.rehydrate({
-                routes: newRoutes
-            });
-            a.plug(p);
-            var c = a.createContext();
-            expect(p.getRoutes()).to.deep.equal(newRoutes);
-            expect(c.getActionContext().router.makePath('foo')).to.equal('/bar');
-            expect(c.getComponentContext().makePath('foo')).to.equal('/bar');
-        });
-    });
-
 });


### PR DESCRIPTION
@lingyan 

Apps should no long rely on routes to be rehydrated and dehydrated. Use an explicit require to your routes when setting up the plugin.
