### PR TITLE
Allow Static and Dynamic Routes

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,2 @@
 node_modules
+artifacts

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Provides routing methods to your [Fluxible](https://github.com/yahoo/fluxible) application using [routr](https://github.com/yahoo/routr).
 
-## Usage
+## Static Routes Usage
 
 ```js
 var Fluxible = require('fluxible');
@@ -31,6 +31,21 @@ var pluginInstance = routrPlugin({
 
 app.plug(pluginInstance);
 ```
+
+## Dynamic Routes Usage
+
+```js
+var Fluxible = require('fluxible');
+var routrPlugin = require('fluxible-plugin-routr');
+var app = new Fluxible();
+
+var pluginInstance = routrPlugin({
+    storeName: 'RoutesStore', // storeName of the Store event source
+    storeEvent: 'change'      // Any event from that Store
+});
+
+app.plug(pluginInstance);
+```
 [//]: # (API_START)
 ## Routr Plugin API
 
@@ -39,7 +54,11 @@ app.plug(pluginInstance);
 Creates a new routr plugin instance with the following parameters:
 
  * `options`: An object containing the plugin settings
- * `options.routes` (required): Stores your routes configuration
+ * `options.routes` (required, static routes): Stores your routes configuration
+ * `options.storeName` (required, dynamic routes): The storeName of the Store
+ * `options.storeEvent` (required, dynamic routes): The name of the event from the Store
+ * `options.dehydrateRoutes` (optional, dynamic routes): A function to transform from fluxible routes to JSON
+ * `options.rehydrateRoutes` (optional, dynamic routes): A function to transform from JSON to fluxible routes
 
 ### Instance Methods
 

--- a/lib/routr-plugin.js
+++ b/lib/routr-plugin.js
@@ -38,6 +38,24 @@ module.exports = function routrPlugin(options) {
             };
         },
         /**
+         * Called to dehydrate plugin options
+         * @method dehydrate
+         * @returns {Object}
+         */
+        dehydrate: function dehydrate() {
+            return {
+                routes: routes
+            };
+        },
+        /**
+         * Called to rehydrate plugin options
+         * @method rehydrate
+         * @returns {Object}
+         */
+        rehydrate: function rehydrate(state) {
+            routes = state.routes;
+        },
+        /**
          * @method getRoutes
          * @returns {Object}
          */

--- a/lib/routr-plugin.js
+++ b/lib/routr-plugin.js
@@ -3,11 +3,23 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+
+var debug = require('debug')('RoutrPlugin');
 var Router = require('routr');
+
+var passThru = function(routes) { return routes; };
 
 module.exports = function routrPlugin(options) {
     options = options || {};
-    var routes = options.routes;
+
+    var staticRoutes = options.routes;
+    var storeName = options.storeName;
+    var storeEvent = options.storeEvent;
+    var dehydrateRoutes = options.dehydrateRoutes || passThru;
+    var rehydrateRoutes = options.rehydrateRoutes || passThru;
+
+    var routes = staticRoutes;
+
     /**
      * @class RoutrPlugin
      */
@@ -19,41 +31,76 @@ module.exports = function routrPlugin(options) {
          * @returns {Object}
          */
         plugContext: function plugContext() {
-            var router = new Router(routes);
-            return {
+            debug('new plug context');
+            var router, actionContext, componentContext;
+
+            if (staticRoutes) {
+                router = new Router(routes);
+            }
+
+            /**
+             * Dynamically update the routes, make a new Router, fix references.
+             *
+             * @param {Object} params
+             * @param {Object} params.routes The new routes to supply Routr
+             */
+            var updateRoutes = function updateRoutes(params) {
+                debug('updating routes');
+                routes = params.routes;
+                router = new Router(routes);
+                if (actionContext) {
+                    actionContext.router = router;
+                }
+                if (componentContext) {
+                    componentContext.makePath = router.makePath.bind(router);
+                }
+            };
+
+            var pluginContext = {
                 /**
                  * Provides full access to the router in the action context
                  * @param {Object} actionContext
                  */
-                plugActionContext: function plugActionContext(actionContext) {
+                plugActionContext: function plugActionContext(context) {
+                    debug('plug action context, router = '+router);
+                    actionContext = context;
                     actionContext.router = router;
+          
+                    if (!staticRoutes) {
+                        // Update on a store event within the single round.
+                        // Could be 'change' from dedicated route store, or
+                        // a dedicated change event within an application store.
+                        actionContext.getStore(storeName)
+                            .removeListener(storeEvent, updateRoutes)
+                            .on(storeEvent, updateRoutes);
+                    }
                 },
                 /**
                  * Provides access to create paths by name
                  * @param {Object} componentContext
                  */
-                plugComponentContext: function plugComponentContext(componentContext) {
-                    componentContext.makePath = router.makePath.bind(router);
+                plugComponentContext: function plugComponentContext(context) {
+                    componentContext = context;
+                    if (router) {
+                        componentContext.makePath = router.makePath.bind(router);
+                    }
                 }
             };
-        },
-        /**
-         * Called to dehydrate plugin options
-         * @method dehydrate
-         * @returns {Object}
-         */
-        dehydrate: function dehydrate() {
-            return {
-                routes: routes
-            };
-        },
-        /**
-         * Called to rehydrate plugin options
-         * @method rehydrate
-         * @returns {Object}
-         */
-        rehydrate: function rehydrate(state) {
-            routes = state.routes;
+      
+            if (!staticRoutes) {
+                // Allows context plugin settings to be persisted between server and client.
+                // Called on server to send data down to the client
+                pluginContext.dehydrate = function dehydrate() {
+                  return { routes: dehydrateRoutes(routes) };
+                };
+
+                // Called on client to rehydrate the context plugin settings
+                pluginContext.rehydrate = function rehydrate(state) {
+                  updateRoutes({ routes: rehydrateRoutes(state.routes) });
+                };
+            }
+
+            return pluginContext;
         },
         /**
          * @method getRoutes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible-plugin-routr",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A plugin for Fluxible applications to provide routing methods",
   "main": "index.js",
   "repository": {
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "mocha tests/unit/ --recursive --reporter spec",
     "cover": "istanbul cover --dir artifacts -- ./node_modules/mocha/bin/_mocha tests/unit/ --recursive --reporter spec",
-    "lint": "jshint"
+    "lint": "jshint ."
   },
   "dependencies": {
     "debug": "^2.0.0",
@@ -28,7 +28,12 @@
     "precommit-hook": "1.0.x"
   },
   "author": "Michael Ridgway <mridgway@yahoo-inc.com>",
-  "contributors": [],
+  "contributors": [
+    {
+      "name": "Alex Grant",
+      "email": "alex@localnerve.com"
+    }
+  ],
   "licenses": [
     {
       "type": "BSD",

--- a/tests/unit/lib/routr-plugin.js
+++ b/tests/unit/lib/routr-plugin.js
@@ -70,4 +70,41 @@ describe('fetchrPlugin', function () {
         });
     });
 
+    describe('dehydrate', function () {        
+        it('should dehydrate its state correctly', function () {       
+            expect(pluginInstance.dehydrate()).to.deep.equal({     
+                routes: routes     
+            });        
+        });        
+    });        
+
+    describe('rehydrate', function () {        
+        var newRoutes = {      
+            foo: {     
+                path: '/bar',      
+                method: 'get'      
+            }      
+        };     
+        it('should rehydrate the state correctly', function () {       
+            pluginInstance.rehydrate({     
+                routes: newRoutes      
+            });        
+            expect(pluginInstance.dehydrate()).to.deep.equal({     
+                routes: newRoutes      
+            });        
+        });        
+        it('should use rehydrated routes', function () {       
+            var a = new Fluxible();
+            var p = routrPlugin();     
+            p.rehydrate({      
+                routes: newRoutes      
+            });        
+            a.plug(p);     
+            var c = a.createContext();     
+            expect(p.getRoutes()).to.deep.equal(newRoutes);        
+            expect(c.getActionContext().router.makePath('foo')).to.equal('/bar');      
+            expect(c.getComponentContext().makePath('foo')).to.equal('/bar');      
+        });        
+    });        
+
 });

--- a/tests/unit/lib/routr-plugin.js
+++ b/tests/unit/lib/routr-plugin.js
@@ -3,17 +3,32 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 /*globals describe,it,beforeEach */
-"use strict";
+'use strict';
 
 var expect = require('chai').expect;
 var routrPlugin = require('../../../lib/routr-plugin');
+var createStore = require('fluxible/utils/createStore');
 var Fluxible = require('fluxible');
+
+var RoutesStore = createStore({
+    storeName: 'RoutesStore',
+    handlers: {
+        'RECEIVE_ROUTES': 'receiveRoutes'
+    },
+    initialize: function() {
+        this.routes = {};
+    },
+    receiveRoutes: function(routes) {
+        this.routes = routes;
+        this.emitChange();
+    }
+});
 
 describe('fetchrPlugin', function () {
     var app,
         pluginInstance,
         context,
-        routes = {
+        routes1 = {
             view_user: {
                 path: '/user/:id',
                 method: 'get',
@@ -25,86 +40,214 @@ describe('fetchrPlugin', function () {
                 path: '/user/:id/post/:post',
                 method: 'get'
             }
+        },
+        routes2 = {
+            view_second: {
+                path: '/second/:id',
+                method: 'get',
+                foo: {
+                    bar: 'all'
+                }
+            }
+        },
+        pluginOptionsDynRoutes = {
+            storeName: RoutesStore.storeName,
+            storeEvent: 'change',
+            dehydrateRoutes: function(routes) { return routes; },
+            rehydrateRoutes: function(routes) { return routes; }
         };
+
+    function actionContextRoutes1(actionContext) {
+        expect(actionContext.router).to.be.an('object');
+        expect(actionContext.router.makePath).to.be.a('function');
+        expect(actionContext.router.getRoute).to.be.a('function');
+        expect(actionContext.router.makePath('view_user', {id: 1})).to.equal('/user/1');
+    }
+    function componentContextRoutes1(componentContext) {
+        expect(componentContext.makePath).to.be.a('function');
+        expect(componentContext.makePath('view_user', {id: 1})).to.equal('/user/1');
+    }
+    function actionContextRoutes2(actionContext) {
+        expect(actionContext.router).to.be.an('object');
+        expect(actionContext.router.makePath).to.be.a('function');
+        expect(actionContext.router.getRoute).to.be.a('function');
+        expect(actionContext.router.makePath('view_second', {id: 2})).to.equal('/second/2');
+    }
+    function componentContextRoutes2(componentContext) {
+        expect(componentContext.makePath).to.be.a('function');
+        expect(componentContext.makePath('view_second', {id: 2})).to.equal('/second/2');
+    }
 
     beforeEach(function () {
         app = new Fluxible();
-        pluginInstance = routrPlugin({
-            routes: routes
-        });
-        app.plug(pluginInstance);
-        context = app.createContext();
     });
 
-    describe('factory', function () {
-        it('should accept routes option', function () {
-            expect(pluginInstance.getRoutes()).to.deep.equal(routes);
+    describe('static routes', function() {
+        beforeEach(function() {
+            pluginInstance = routrPlugin({ routes: routes1 });
+            app.plug(pluginInstance);
+            context = app.createContext();
         });
-    });
 
-    describe('actionContext', function () {
-        var actionContext;
-        beforeEach(function () {
-            actionContext = context.getActionContext();
+        describe('factory', function () {
+            it('should accept static routes option', function () {
+                expect(pluginInstance.getRoutes()).to.deep.equal(routes1);
+            });
         });
-        describe('router', function () {
-            it('should have a router access', function () {
-                expect(actionContext.router).to.be.an('object');
-                expect(actionContext.router.makePath).to.be.a('function');
-                expect(actionContext.router.getRoute).to.be.a('function');
-                expect(actionContext.router.makePath('view_user', {id: 1})).to.equal('/user/1');
+
+        describe('actionContext', function () {
+            var actionContext;
+            beforeEach(function () {
+                actionContext = context.getActionContext();
+            });
+            describe('router', function () {
+                it('should have a router access', function () {
+                    actionContextRoutes1(actionContext);
+                });
+            });
+        });
+
+        describe('componentContext', function () {
+            var componentContext;
+            beforeEach(function () {
+                componentContext = context.getComponentContext();
+            });
+            describe('router', function () {
+                it('should have a router access', function () {
+                    componentContextRoutes1(componentContext);
+                });
+            });
+        });
+
+        describe('rehydrate/dehydrate', function() {
+            it('should not have plugin rehydrate/dehydrate', function() {
+                expect(pluginInstance.dehydrate).to.be.an('undefined');
+                expect(pluginInstance.rehydrate).to.be.an('undefined');
+            });
+            it('should not have a context rehydrate/dehydrate', function() {
+                var contextPlug = pluginInstance.plugContext();
+                expect(contextPlug.dehydrate).to.be.an('undefined');
+                expect(contextPlug.rehydrate).to.be.an('undefined');
             });
         });
     });
 
-    describe('componentContext', function () {
-        var componentContext;
-        beforeEach(function () {
-            componentContext = context.getComponentContext();
+    describe('dynamic routes', function() {
+        beforeEach(function() {
+            pluginInstance = routrPlugin(pluginOptionsDynRoutes);
+            app.plug(pluginInstance);
+            app.registerStore(RoutesStore);
+            context = app.createContext();
         });
-        describe('router', function () {
-            it('should have a router access', function () {
-                expect(componentContext.makePath).to.be.a('function');
-                expect(componentContext.makePath('view_user', {id: 1})).to.equal('/user/1');
+
+        describe('factory', function () {
+            it('should not have any routes defined', function () {
+                expect(pluginInstance.getRoutes()).to.be.an('undefined');
+            });
+        });
+
+        describe('dehydrate/rehydrate', function() {
+            var dehydratedState = {
+                routes: pluginOptionsDynRoutes.dehydrateRoutes(routes1)
+            };
+            it('should have context rehydrate/dehydrate', function() {
+                var contextPlug = pluginInstance.plugContext();
+                expect(contextPlug.dehydrate).to.be.a('function');
+                expect(contextPlug.rehydrate).to.be.a('function');
+            });
+            describe('rehydrate', function() {
+                beforeEach(function() {
+                    context.rehydrate({
+                        plugins: {
+                            RoutrPlugin: dehydratedState
+                        }
+                    });
+                });
+                it('should have routes', function() {
+                    expect(pluginInstance.getRoutes()).to.eql(routes1);
+                });
+                describe('actionContext', function() {
+                    var actionContext;
+                    beforeEach(function() {
+                        actionContext = context.getActionContext();
+                    });
+                    it('should have a router access', function () {
+                        actionContextRoutes1(actionContext);
+                    });
+                });
+                describe('componentContext', function() {
+                    var componentContext;
+                    beforeEach(function() {
+                        componentContext = context.getComponentContext();
+                    });
+                    it('should have a router access', function () {
+                        componentContextRoutes1(componentContext);
+                    });
+                });
+            });
+            describe('dehydrate', function() {
+                var contextPlug;
+                beforeEach(function() {
+                    contextPlug = pluginInstance.plugContext();
+                    contextPlug.rehydrate(dehydratedState);
+                });
+                it('should dehydrate using dehydrateRoutes', function() {
+                    expect(contextPlug.dehydrate(routes1)).to.eql(dehydratedState);
+                });
+            });
+        });
+
+        describe('updateRoutes', function() {
+            var actionContext;
+            beforeEach(function() {
+                actionContext = context.getActionContext();
+            });
+            it('should update with routes1 when store updates', function() {
+                actionContext.dispatch('RECEIVE_ROUTES', routes1);
+                expect(pluginInstance.getRoutes()).to.eql(routes1);
+            });
+            it('should update with routes2 when store updates', function() {                
+                actionContext.dispatch('RECEIVE_ROUTES', routes2);
+                expect(pluginInstance.getRoutes()).to.eql(routes2);
+            });
+            describe('context updates', function() {
+                describe('routes1', function() {
+                    describe('actionContext', function() {
+                        it('should have a router access', function () {
+                            actionContext.dispatch('RECEIVE_ROUTES', routes1);
+                            actionContextRoutes1(actionContext);
+                        });
+                    });
+                    describe('componentContext', function() {
+                        var componentContext;
+                        beforeEach(function() {
+                            componentContext = context.getComponentContext();
+                        });
+                        it('should have a router access', function () {
+                            actionContext.dispatch('RECEIVE_ROUTES', routes1);
+                            componentContextRoutes1(componentContext);
+                        });
+                    });
+                });
+                describe('routes2', function() {
+                    describe('actionContext', function() {
+                        it('should have a router access', function (){
+                            actionContext.dispatch('RECEIVE_ROUTES', routes2);
+                            actionContextRoutes2(actionContext);
+                        });
+                    });
+                    describe('componentContext', function() {
+                        var componentContext;
+                        beforeEach(function() {
+                            componentContext = context.getComponentContext();
+                        });
+                        it('should have a router access', function () {
+                            actionContext.dispatch('RECEIVE_ROUTES', routes2);
+                            componentContextRoutes2(componentContext);
+                        });
+                    });
+                });
             });
         });
     });
-
-    describe('dehydrate', function () {        
-        it('should dehydrate its state correctly', function () {       
-            expect(pluginInstance.dehydrate()).to.deep.equal({     
-                routes: routes     
-            });        
-        });        
-    });        
-
-    describe('rehydrate', function () {        
-        var newRoutes = {      
-            foo: {     
-                path: '/bar',      
-                method: 'get'      
-            }      
-        };     
-        it('should rehydrate the state correctly', function () {       
-            pluginInstance.rehydrate({     
-                routes: newRoutes      
-            });        
-            expect(pluginInstance.dehydrate()).to.deep.equal({     
-                routes: newRoutes      
-            });        
-        });        
-        it('should use rehydrated routes', function () {       
-            var a = new Fluxible();
-            var p = routrPlugin();     
-            p.rehydrate({      
-                routes: newRoutes      
-            });        
-            a.plug(p);     
-            var c = a.createContext();     
-            expect(p.getRoutes()).to.deep.equal(newRoutes);        
-            expect(c.getActionContext().router.makePath('foo')).to.equal('/bar');      
-            expect(c.getComponentContext().makePath('foo')).to.equal('/bar');      
-        });        
-    });        
-
 });


### PR DESCRIPTION
Hello, and thank you for this great architecture for working with Flux and React.

This fork allows both static and dynamic route specs with fluxible. The idea is that route specs can come from the backend, not just be defined in the application code.
A working example of the dynamic usage is available in this [example](https://github.com/localnerve/flux-react-example).
Readme and tests were expanded to cover the new functionality.
I find this fork very useful, and thought maybe you might too.

Thanks again,
Alex
